### PR TITLE
Use an older version of "cppzst"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "cppzst": "^2.0.6"
+    "cppzst": "2.0.6"
   },
   "funding": "https://github.com/sponsors/Nevon/",
   "publishConfig": {


### PR DESCRIPTION
As @TheZwieback explained in issue https://github.com/kafkajs/zstd/issues/3, the new release 2.0.7 of the dependency "cppzst" refactored to an ECMA module with an index.mjs file and does not work with @kafkajs/zstf. Basically @kafkajs/zstf is broken. It will trigger an `[ERR_REQUIRE_ESM]: Must use import to load ES Module` error whenever it's loaded. Using the older version 2.0.6 of "cppzst" resolves the issue for now. It is not a permanent solve though.